### PR TITLE
Allow other methods for stats posting

### DIFF
--- a/src/routes/count.js
+++ b/src/routes/count.js
@@ -66,7 +66,7 @@ module.exports = {
 
             // Make the request
             return fetch(list.api_post.replace(':id', data.bot_id), {
-                method: 'POST',
+                method: list.api_post_method ?? 'POST',
                 body: JSON.stringify(payload),
                 headers: {
                     Authorization: data[list.id],


### PR DESCRIPTION
Fixes https://github.com/botblock/api-worker/issues/2

This *probably* works. I have not tested it. YOLO